### PR TITLE
remove xinclude in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ include(${GKLIB_PATH}/GKlibSystem.cmake)
 include_directories(${GKLIB_PATH})
 include_directories(build/xinclude)
 # Recursively look for CMakeLists.txt in subdirs.
-add_subdirectory("build/xinclude")
 add_subdirectory("libmetis")
 add_subdirectory("programs")
+
+INSTALL (
+    DIRECTORY build/xinclude/
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h*")


### PR DESCRIPTION
I believe `add_subdirectory("build/xinclude")` is used for installation of the new header files. It makes DGL to fail to compile.