### PR TITLE
Remove an unnecessary path and simplify linking commands.

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # These programs use internal metis data structures.
 include_directories(../libmetis)
-link_directories(/home/karypis/local/lib)
+link_libraries(metis)
 # Build program.
 add_executable(gpmetis gpmetis.c cmdline_gpmetis.c io.c stat.c)
 add_executable(ndmetis ndmetis.c cmdline_ndmetis.c io.c smbfactor.c)
@@ -8,10 +8,6 @@ add_executable(mpmetis mpmetis.c cmdline_mpmetis.c io.c stat.c)
 add_executable(m2gmetis m2gmetis.c cmdline_m2gmetis.c io.c)
 add_executable(graphchk graphchk.c io.c)
 add_executable(cmpfillin cmpfillin.c io.c smbfactor.c)
-foreach(prog gpmetis ndmetis mpmetis m2gmetis graphchk cmpfillin)
-  target_link_libraries(${prog} metis)
-#  target_link_libraries(${prog} metis profiler)
-endforeach(prog)
 
 if(METIS_INSTALL)
   install(TARGETS gpmetis ndmetis mpmetis m2gmetis graphchk cmpfillin


### PR DESCRIPTION
1. The removed absolute path only works on @karypis 's machine. It is unnecessary since the `metis` target already contains the path info.
2. All of the executables link to the same `metis` target, so the [`foreach`](https://cmake.org/cmake/help/latest/command/foreach.html) block can be simplified by a single [`link_libraries`](https://cmake.org/cmake/help/latest/command/link_libraries.html) command.