### PR TITLE
Support CMake-only build and submoduling.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,33 @@
+name: CMake-only Build
+on: [push, pull_request]
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+jobs:
+  build:
+    runs-on: ${{ matrix.os }} # For each os, run this job on it.
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{ runner.workspace }}/build
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(METIS C)
 
-set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
+set(GKLIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
 set(SHARED FALSE CACHE BOOL "build a shared library")
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,26 +20,28 @@ endif(SHARED)
 include(${GKLIB_PATH}/GKlibSystem.cmake)
 
 # METIS' custom options
-#option(IDX64 "enable 64 bit ints" OFF)
-#option(REAL64 "enable 64 bit floats (i.e., double)" OFF)
-#if(IDX64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=32")
-#endif(IDX64)
-#if(REAL64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=32")
-#endif(REAL64)
-#
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${METIS_COPTIONS}")
-
+option(METIS_IDX64 "enable 64 bit ints" OFF)
+option(METIS_REAL64 "enable 64 bit floats (i.e., double)" OFF)
+if (METIS_IDX64)
+  set(METIS_IDXTYPEWIDTH 64)
+else ()
+  set(METIS_IDXTYPEWIDTH 32)
+endif ()
+if (METIS_REAL64)
+  set(METIS_REALTYPEWIDTH 64)
+else ()
+  set(METIS_REALTYPEWIDTH 32)
+endif ()
 
 # Add include directories.
 include_directories(${GKLIB_PATH})
-include_directories(build/xinclude)
+configure_file(${PROJECT_SOURCE_DIR}/include/metis.h.in
+               ${PROJECT_BINARY_DIR}/include/metis.h)
+include_directories(${PROJECT_BINARY_DIR}/include)
+if (METIS_INSTALL)
+  install(FILES ${PROJECT_BINARY_DIR}/include/metis.h DESTINATION include)
+endif ()
+
 # Recursively look for CMakeLists.txt in subdirs.
-add_subdirectory("build/xinclude")
 add_subdirectory("libmetis")
 add_subdirectory("programs")

--- a/include/metis.h.in
+++ b/include/metis.h.in
@@ -30,7 +30,7 @@
  GCC does provides these definitions in stdint.h, but it may require some
  modifications on other architectures.
 --------------------------------------------------------------------------*/
-//#define IDXTYPEWIDTH 32
+#define IDXTYPEWIDTH @METIS_IDXTYPEWIDTH@
 
 
 /*--------------------------------------------------------------------------
@@ -40,7 +40,7 @@
    32 : single precission floating point (float)
    64 : double precission floating point (double)
 --------------------------------------------------------------------------*/
-//#define REALTYPEWIDTH 32
+#define REALTYPEWIDTH @METIS_REALTYPEWIDTH@
 
 
 


### PR DESCRIPTION
This request has already been proposed in #2 and #7.

The main reason (as I understand) to use a `Makefile` as a preprocessor is to prepend two `#define` lines to `metis.h`, which then might be installed somewhere (currently in `~/local` by default). As @karypis mentioned in #2, the attempt made by @zheng-da leaves the burden of defining these macros to the user of (the installed) METIS, since the installed `metis.h`, which is copied from the source directory, has commented out these two lines.

My attempt is based on the [`configure_file()`](https://cmake.org/cmake/help/latest/command/configure_file.html) command, which sets the values of `IDXTYPEWIDTH` and `REALTYPEWIDTH` in the _configuration_ stage. The configured `metis.h`, which contains the two `#define`s, will then be used to build the targets in this project, and will be copied to `${CMAKE_INSTALL_PREFIX}/include` in the _installation_ stage. At the point of running `make install` or `ninja install` (as mentioned by @gruenich in #7), my approach has the same effect as the current `Makefile`-driven one.