### PR TITLE
Remove trailing comma

### DIFF
--- a/include/metis.h
+++ b/include/metis.h
@@ -342,7 +342,7 @@ typedef enum {
   METIS_DBG_SEPINFO    = 64, 	  /*!< Show info on vertex moves during sep refinement */
   METIS_DBG_CONNINFO   = 128,     /*!< Show info on minimization of subdomain connectivity */
   METIS_DBG_CONTIGINFO = 256,     /*!< Show info on elimination of connected components */ 
-  METIS_DBG_MEMORY     = 2048,    /*!< Show info related to wspace allocation */
+  METIS_DBG_MEMORY     = 2048     /*!< Show info related to wspace allocation */
 } mdbglvl_et;
 
 


### PR DESCRIPTION
Remove comma at end of enumerator list due to compilation failure with
ancient gcc (4.3.4)