### PR TITLE
Fix various source comment and doc typos

### DIFF
--- a/include/metis.h
+++ b/include/metis.h
@@ -37,8 +37,8 @@
  Specifies the data type that will hold floating-point style information.
 
  Possible values:
-   32 : single precission floating point (float)
-   64 : double precission floating point (double)
+   32 : single precision floating point (float)
+   64 : double precision floating point (double)
 --------------------------------------------------------------------------*/
 //#define REALTYPEWIDTH 32
 

--- a/libmetis/auxapi.c
+++ b/libmetis/auxapi.c
@@ -13,7 +13,7 @@
 
 
 /*************************************************************************/
-/*! This function free memory that was allocated by METIS and retuned
+/*! This function frees memory that was allocated by METIS and returns
     to the application.
     
     \param ptr points to the memory that was previously allocated by

--- a/libmetis/balance.c
+++ b/libmetis/balance.c
@@ -161,7 +161,7 @@ void Bnd2WayBalance(ctrl_t *ctrl, graph_t *graph, real_t *ntpwgts)
 /*************************************************************************
 * This function balances two partitions by moving the highest gain 
 * (including negative gain) vertices to the other domain.
-* It is used only when tha unbalance is due to non contigous
+* It is used only when the unbalance is due to non contiguous
 * subdomains. That is, the are no boundary vertices.
 * It moves vertices from the domain that is overweight to the one that 
 * is underweight.

--- a/libmetis/contig.c
+++ b/libmetis/contig.c
@@ -178,7 +178,7 @@ idx_t IsConnected(graph_t *graph, idx_t report)
 
 
 /*************************************************************************/
-/*! This function checks whether or not partition pid is contigous
+/*! This function checks whether or not partition pid is contiguous
   */
 /*************************************************************************/
 idx_t IsConnectedSubdomain(ctrl_t *ctrl, graph_t *graph, idx_t pid, idx_t report)

--- a/libmetis/debug.c
+++ b/libmetis/debug.c
@@ -3,7 +3,7 @@
  *
  * debug.c
  *
- * This file contains code that performs self debuging
+ * This file contains code that performs self debugging
  *
  * Started 7/24/97
  * George

--- a/libmetis/defs.h
+++ b/libmetis/defs.h
@@ -45,7 +45,7 @@
 #define LARGENIPARTS		7	/* Number of random initial partitions */
 #define SMALLNIPARTS		5	/* Number of random initial partitions */
 
-#define COARSEN_FRACTION	0.85	/* Node reduction between succesive coarsening levels */
+#define COARSEN_FRACTION	0.85	/* Node reduction between successive coarsening levels */
 
 #define COMPRESSION_FRACTION		0.85
 

--- a/libmetis/fm.c
+++ b/libmetis/fm.c
@@ -452,7 +452,7 @@ void SelectQueue(graph_t *graph, real_t *pijbm, real_t *ubfactors,
   for (max=0.0, part=0; part<2; part++) {
     for (i=0; i<ncon; i++) {
       tmp = graph->pwgts[part*ncon+i]*pijbm[part*ncon+i] - ubfactors[i];
-      /* the '=' in the test bellow is to ensure that under tight constraints
+      /* the '=' in the test below is to ensure that under tight constraints
          the partition that is at the max is selected */
       if (tmp >= max) { 
         max   = tmp;

--- a/libmetis/graph.c
+++ b/libmetis/graph.c
@@ -129,7 +129,7 @@ void SetupGraph_label(graph_t *graph)
 
 
 /*************************************************************************/
-/*! Setup the various arrays for the splitted graph */
+/*! Setup the various arrays for the split graph */
 /*************************************************************************/
 graph_t *SetupSplitGraph(graph_t *graph, idx_t snvtxs, idx_t snedges)
 {
@@ -141,7 +141,7 @@ graph_t *SetupSplitGraph(graph_t *graph, idx_t snvtxs, idx_t snedges)
   sgraph->nedges = snedges;
   sgraph->ncon   = graph->ncon;
 
-  /* Allocate memory for the splitted graph */
+  /* Allocate memory for the split graph */
   sgraph->xadj        = imalloc(snvtxs+1, "SetupSplitGraph: xadj");
   sgraph->vwgt        = imalloc(sgraph->ncon*snvtxs, "SetupSplitGraph: vwgt");
   sgraph->adjncy      = imalloc(snedges,  "SetupSplitGraph: adjncy");

--- a/libmetis/initpart.c
+++ b/libmetis/initpart.c
@@ -94,7 +94,7 @@ void InitSeparator(ctrl_t *ctrl, graph_t *graph, idx_t niparts)
       break;
 
     default:
-      gk_errexit(SIGERR, "Unkown iptype of %"PRIDX"\n", ctrl->iptype);
+      gk_errexit(SIGERR, "Unknown iptype of %"PRIDX"\n", ctrl->iptype);
   }
 
   IFSET(ctrl->dbglvl, METIS_DBG_IPART, printf("Initial Sep: %"PRIDX"\n", graph->mincut));
@@ -346,7 +346,7 @@ void McRandomBisection(ctrl_t *ctrl, graph_t *graph, real_t *ntpwgts,
     irandArrayPermute(nvtxs, perm, nvtxs/2, 1);
     iset(ncon, 0, counts);
 
-    /* partition by spliting the queues randomly */
+    /* partition by splitting the queues randomly */
     for (ii=0; ii<nvtxs; ii++) {
       i        = perm[ii];
       qnum     = iargmax(ncon, vwgt+i*ncon,1);

--- a/libmetis/kmetis.c
+++ b/libmetis/kmetis.c
@@ -100,7 +100,7 @@ SIGTHROW:
     \param graph is the graph to be partitioned
     \param part is the vector that on return will store the partitioning
 
-    \returns the objective value of the partitoning. The partitioning 
+    \returns the objective value of the partitioning. The partitioning 
              itself is stored in the part vector.
 */
 /*************************************************************************/
@@ -256,7 +256,7 @@ void InitKWayPartitioning(ctrl_t *ctrl, graph_t *graph)
     \param graph is the graph to be partitioned
     \param part is the vector that on return will store the partitioning
 
-    \returns the objective value of the partitoning. The partitioning 
+    \returns the objective value of the partitioning. The partitioning 
              itself is stored in the part vector.
 */
 /*************************************************************************/
@@ -443,7 +443,7 @@ void BalanceAndRefineLP(ctrl_t *ctrl, graph_t *graph, idx_t nparts, idx_t *where
   /* for randomly visiting the vertices */
   perm = iincset(nvtxs, 0, iwspacemalloc(ctrl, nvtxs));
 
-  /* for keeping track of adjancent partitions */
+  /* for keeping track of adjacent partitions */
   nbrids  = iwspacemalloc(ctrl, nparts);
   nbrwgts = iset(nparts, 0, iwspacemalloc(ctrl, nparts));
   nbrmrks = iset(nparts, -1, iwspacemalloc(ctrl, nparts));

--- a/libmetis/kwayfm.c
+++ b/libmetis/kwayfm.c
@@ -300,7 +300,7 @@ void Greedy_KWayCutOptimize0(ctrl_t *ctrl, graph_t *graph, idx_t niter,
         /* take care of i's move itself */
         UpdateEdgeSubDomainGraph(ctrl, from, to, myrinfo->id-mynbrs[k].ed, &maxndoms);
 
-        /* take care of the adjancent vertices */
+        /* take care of the adjacent vertices */
         for (j=xadj[i]; j<xadj[i+1]; j++) {
           me = where[adjncy[j]];
           if (me != from && me != to) {
@@ -642,7 +642,7 @@ void Greedy_KWayCutOptimize(ctrl_t *ctrl, graph_t *graph, idx_t niter,
         /* take care of i's move itself */
         UpdateEdgeSubDomainGraph(ctrl, from, to, myrinfo->id-mynbrs[k].ed, &maxndoms);
 
-        /* take care of the adjancent vertices */
+        /* take care of the adjacent vertices */
         for (j=xadj[i]; j<xadj[i+1]; j++) {
           me = where[adjncy[j]];
           if (me != from && me != to) {
@@ -968,7 +968,7 @@ void Greedy_KWayVolOptimize(ctrl_t *ctrl, graph_t *graph, idx_t niter,
         /* take care of i's move itself */
         UpdateEdgeSubDomainGraph(ctrl, from, to, myrinfo->nid-mynbrs[k].ned, &maxndoms);
 
-        /* take care of the adjancent vertices */
+        /* take care of the adjacent vertices */
         for (j=xadj[i]; j<xadj[i+1]; j++) {
           me = where[adjncy[j]];
           if (me != from && me != to) {
@@ -1300,7 +1300,7 @@ void Greedy_McKWayCutOptimize(ctrl_t *ctrl, graph_t *graph, idx_t niter,
         /* take care of i's move itself */
         UpdateEdgeSubDomainGraph(ctrl, from, to, myrinfo->id-mynbrs[k].ed, &maxndoms);
 
-        /* take care of the adjancent vertices */
+        /* take care of the adjacent vertices */
         for (j=xadj[i]; j<xadj[i+1]; j++) {
           me = where[adjncy[j]];
           if (me != from && me != to) {
@@ -1654,7 +1654,7 @@ void Greedy_McKWayVolOptimize(ctrl_t *ctrl, graph_t *graph, idx_t niter,
         /* take care of i's move itself */
         UpdateEdgeSubDomainGraph(ctrl, from, to, myrinfo->nid-mynbrs[k].ned, &maxndoms);
 
-        /* take care of the adjancent vertices */
+        /* take care of the adjacent vertices */
         for (j=xadj[i]; j<xadj[i+1]; j++) {
           me = where[adjncy[j]];
           if (me != from && me != to) {
@@ -1804,7 +1804,7 @@ idx_t IsArticulationNode(idx_t i, idx_t *xadj, idx_t *adjncy, idx_t *where,
         the queue. If queue is NULL, this parameter is ignored.
  \param vmarker is of size nvtxs and is used internally as a temporary array. 
         On entry and return all of its entries are 0.
- \param pmarker is of sie nparts and is used internally as a temporary marking
+ \param pmarker is of size nparts and is used internally as a temporary marking
         array. On entry and return all of its entries are -1.
  \param modind is an array of size nvtxs and is used to keep track of the 
         list of vertices whose gains need to be updated.

--- a/libmetis/kwayrefine.c
+++ b/libmetis/kwayrefine.c
@@ -147,7 +147,7 @@ void AllocateKWayPartitionMemory(ctrl_t *ctrl, graph_t *graph)
 
 /*************************************************************************/
 /*! This function computes the initial id/ed  for cut-based partitioning */
-/**************************************************************************/
+/*************************************************************************/
 void ComputeKWayPartitionParams(ctrl_t *ctrl, graph_t *graph)
 {
   idx_t i, j, k, l, nvtxs, ncon, nparts, nbnd, mincut, me, other;
@@ -671,7 +671,7 @@ void ComputeKWayVolGains(ctrl_t *ctrl, graph_t *graph)
 
 /*************************************************************************/
 /*! This function checks if the partition weights are within the balance
-contraints */
+constraints */
 /*************************************************************************/
 int IsBalanced(ctrl_t *ctrl, graph_t *graph, real_t ffactor)
 {

--- a/libmetis/minconn.c
+++ b/libmetis/minconn.c
@@ -678,7 +678,7 @@ void MoveGroupMinConnForVol(ctrl_t *ctrl, graph_t *graph, idx_t to, idx_t nind,
 
 
 /*************************************************************************/
-/*! This function computes the subdomain graph. For deubuging purposes. */
+/*! This function computes the subdomain graph. For deubugging purposes. */
 /*************************************************************************/
 void PrintSubDomainGraph(graph_t *graph, idx_t nparts, idx_t *where)
 {

--- a/libmetis/mincover.c
+++ b/libmetis/mincover.c
@@ -121,7 +121,7 @@ void MinCover(idx_t *xadj, idx_t *adjncy, idx_t asize, idx_t bsize, idx_t *cover
 
 
 /*************************************************************************
-* This function perfoms a restricted DFS and augments matchings
+* This function performs a restricted DFS and augments matchings
 **************************************************************************/
 idx_t MinCover_Augment(idx_t *xadj, idx_t *adjncy, idx_t col, idx_t *mate, idx_t *flag, idx_t *level, idx_t maxlevel)
 {
@@ -206,7 +206,7 @@ void MinCover_Decompose(idx_t *xadj, idx_t *adjncy, idx_t asize, idx_t bsize, id
 
 
 /*************************************************************************
-* This function perfoms a dfs starting from an unmatched col node
+* This function performs a dfs starting from an unmatched col node
 * forming alternate paths
 **************************************************************************/
 void MinCover_ColDFS(idx_t *xadj, idx_t *adjncy, idx_t root, idx_t *mate, idx_t *where, idx_t flag)
@@ -231,7 +231,7 @@ void MinCover_ColDFS(idx_t *xadj, idx_t *adjncy, idx_t root, idx_t *mate, idx_t 
 }
 
 /*************************************************************************
-* This function perfoms a dfs starting from an unmatched col node
+* This function performs a dfs starting from an unmatched col node
 * forming alternate paths
 **************************************************************************/
 void MinCover_RowDFS(idx_t *xadj, idx_t *adjncy, idx_t root, idx_t *mate, idx_t *where, idx_t flag)

--- a/libmetis/parmetis.c
+++ b/libmetis/parmetis.c
@@ -316,7 +316,7 @@ void FM_2WayNodeRefine1SidedP(ctrl_t *ctrl, graph_t *graph,
 
       ASSERT(bndptr[higain] != -1);
 
-      /* The following check is to ensure we break out if there is a posibility
+      /* The following check is to ensure we break out if there is a possibility
          of over-running the mind array.  */
       if (nmind + xadj[higain+1]-xadj[higain] >= 2*nvtxs-1)
         break;
@@ -574,7 +574,7 @@ void FM_2WayNodeRefine2SidedP(ctrl_t *ctrl, graph_t *graph,
 
       ASSERT(bndptr[higain] != -1);
 
-      /* The following check is to ensure we break out if there is a posibility
+      /* The following check is to ensure we break out if there is a possibility
          of over-running the mind array.  */
       if (nmind + xadj[higain+1]-xadj[higain] >= 2*nvtxs-1)
         break;

--- a/libmetis/pmetis.c
+++ b/libmetis/pmetis.c
@@ -34,7 +34,7 @@
 
     \param[in] adjncy is an array of size to the sum of the degrees of the
            graph that stores for each vertex the set of vertices that
-           is adjancent to.
+           is adjacent to.
 
     \param[in] vwgt is an array of size nvtxs*ncon that stores the weights
            of the vertices for each constraint. The ncon weights for the

--- a/libmetis/sfm.c
+++ b/libmetis/sfm.c
@@ -3,7 +3,7 @@
  *
  * sfm.c
  *
- * This file contains code that implementes an FM-based separator refinement
+ * This file contains code that implements an FM-based separator refinement
  *
  * Started 8/1/97
  * George
@@ -119,7 +119,7 @@ void FM_2WayNodeRefine2Sided(ctrl_t *ctrl, graph_t *graph, idx_t niter)
 
       ASSERT(bndptr[higain] != -1);
 
-      /* The following check is to ensure we break out if there is a posibility
+      /* The following check is to ensure we break out if there is a possibility
          of over-running the mind array.  */
       if (nmind + xadj[higain+1]-xadj[higain] >= 2*nvtxs-1) 
         break;
@@ -333,7 +333,7 @@ void FM_2WayNodeRefine1Sided(ctrl_t *ctrl, graph_t *graph, idx_t niter)
 
       ASSERT(bndptr[higain] != -1);
 
-      /* The following check is to ensure we break out if there is a posibility
+      /* The following check is to ensure we break out if there is a possibility
          of over-running the mind array.  */
       if (nmind + xadj[higain+1]-xadj[higain] >= 2*nvtxs-1) 
         break;

--- a/libmetis/srefine.c
+++ b/libmetis/srefine.c
@@ -3,7 +3,7 @@
  *
  * srefine.c
  *
- * This file contains code for the separator refinement algortihms
+ * This file contains code for the separator refinement algorithms
  *
  * Started 8/1/97
  * George

--- a/libmetis/struct.h
+++ b/libmetis/struct.h
@@ -98,7 +98,7 @@ typedef struct graph_t {
 
   idx_t *cmap;  /* The contraction/coarsening map */
 
-  idx_t *label; /* The labels of the vertices for recusive bisection (pmetis/ometis) */
+  idx_t *label; /* The labels of the vertices for recursive bisection (pmetis/ometis) */
 
   /* Partition parameters */
   idx_t mincut, minvol;
@@ -148,7 +148,7 @@ typedef struct mesh_t {
 typedef struct ctrl_t {
   moptype_et  optype;	        /* Type of operation */
   mobjtype_et objtype;          /* Type of refinement objective */
-  mdbglvl_et  dbglvl;		/* Controls the debuging output of the program */
+  mdbglvl_et  dbglvl;		/* Controls the debugging output of the program */
   mctype_et   ctype;		/* The type of coarsening */
   miptype_et  iptype;		/* The type of initial partitioning */
   mrtype_et   rtype;		/* The type of refinement */
@@ -158,7 +158,7 @@ typedef struct ctrl_t {
   idx_t no2hop;                 /* Indicates if 2-hop matching will be used */
   idx_t ondisk;                 /* Indicates out-of-core execution */
   idx_t minconn;                /* Indicates if the subdomain connectivity will be minimized */
-  idx_t contig;                 /* Indicates if contigous partitions are required */
+  idx_t contig;                 /* Indicates if contiguous partitions are required */
   idx_t nseps;			/* The number of separators to be found during multiple bisections */
   idx_t ufactor;                /* The user-supplied load imbalance factor */
   idx_t compress;               /* If the graph will be compressed prior to ordering */
@@ -209,7 +209,7 @@ typedef struct ctrl_t {
   idx_t *nads;                  /* The number of adjacent domains */
   idx_t **adids;                /* The IDs of the adjacent domains */
   idx_t **adwgts;               /* The edge-weight to the adjacent domains */
-  idx_t *pvec1, *pvec2;         /* Auxiliar nparts-size vectors for efficiency */
+  idx_t *pvec1, *pvec2;         /* Auxiliary nparts-size vectors for efficiency */
 
   /* ondisk related info */
   pid_t pid;            /*!< The pid of the running process */

--- a/programs/m2gmetis.c
+++ b/programs/m2gmetis.c
@@ -3,7 +3,7 @@
  *
  * m2gmetis.c
  *
- * Drivers for the mesh-to-graph coversion routines
+ * Drivers for the mesh-to-graph conversion routines
  *
  * Started 5/28/11
  * George

--- a/programs/ndmetis.c
+++ b/programs/ndmetis.c
@@ -3,7 +3,7 @@
  *
  * ndmetis.c
  *
- * Driver programs for nested disection ordering
+ * Driver programs for nested dissection ordering
  *
  * Started 8/28/94
  * George

--- a/programs/stat.c
+++ b/programs/stat.c
@@ -35,7 +35,7 @@ void ComputePartitionInfo(params_t *params, graph_t *graph, idx_t *where)
   nparts = params->nparts;
   tpwgts = params->tpwgts;
 
-  /* Compute objective-related infomration */
+  /* Compute objective-related information */
   printf(" - Edgecut: %"PRIDX", communication volume: %"PRIDX".\n\n", 
       ComputeCut(graph, where), ComputeVolume(graph, where));
 


### PR DESCRIPTION
Found via `codespell -q 3 -L ifset,ned,nd,`