### PR TITLE
Add missing changelog entry for 5.2.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,12 @@
+metis-5.2.1
+------------------------------------------------------------------------
+f5ae915 | karypis | 2022-12-05 07:27:57 -0600 (Mon, 05 Dec 2022)
+
+- Added RCM-based reordering auxialiary routine
+  METIS_CacheFriendlyReordering.
+- Improved multi-way BFS and further refined LP-based refinement.
+- GKlib became an external dependency.
+
 
 metis-5.1.0
 ------------------------------------------------------------------------


### PR DESCRIPTION
Thanks for tagging release 5.2.1. Unfortunately, you missed to add a changelog entry. This merge request is my suggestion for adding a changelog entry retroactively.