### PR TITLE
Add support for querying the version info at runtime.

### DIFF
--- a/include/metis.h
+++ b/include/metis.h
@@ -214,6 +214,9 @@ METIS_API(int) METIS_Free(void *ptr);
 
 METIS_API(int) METIS_SetDefaultOptions(idx_t *options);
 
+METIS_API(int) METIS_Version(int *major, int *minor, int *subminor, int *idx_bits,
+                  int *real_bits);
+
 
 /* These functions are used by ParMETIS */
 

--- a/libmetis/util.c
+++ b/libmetis/util.c
@@ -135,4 +135,27 @@ int metis_rcode(int sigrval)
   }
 }
 
+/*****************************************************************************/
+/*! This function returns version and data type information. All arguments are
+    optional and may be NULL.
+
+    \param major will hold the major version.
+    \param minor will hold the minor version.
+    \param subminor will hold the subminor version.
+    \param idx_bits will hold sizeof(idx_t)*8.
+    \param idx_bits will hold sizeof(real_t)*8
+
+*/
+/*****************************************************************************/
+int METIS_Version(int *major, int *minor, int *subminor, int *idx_bits,
+                  int *real_bits)
+{
+  if (major) *major = METIS_VER_MAJOR;
+  if (minor) *minor = METIS_VER_MINOR;
+  if (subminor) *subminor = METIS_VER_SUBMINOR;
+  if (idx_bits) *idx_bits = sizeof(idx_t)*8;
+  if (real_bits) *real_bits = sizeof(real_t)*8;
+
+  return METIS_OK;
+}
 


### PR DESCRIPTION
This is useful for applications which link against METIS as a shared library without access to the header file.  At the moment they are in the dark about what options are available and what the data type sizes are.  This PR adds a simple function to enable them to reliably query these facts.