### PR TITLE
Return an error when initial partitionning fails because trying to partition a graph into too many parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ graphs/*.npart.*
 GKlib
 .svn/
 
+# VSCode things
+.vscode/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,20 +19,20 @@ endif(SHARED)
 include(./conf/gkbuild.cmake)
 
 # METIS' custom options
-#option(IDX64 "enable 64 bit ints" OFF)
-#option(REAL64 "enable 64 bit floats (i.e., double)" OFF)
-#if(IDX64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=32")
-#endif(IDX64)
-#if(REAL64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=32")
-#endif(REAL64)
-#
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${METIS_COPTIONS}")
+option(IDX64 "enable 64 bit ints" OFF)
+option(REAL64 "enable 64 bit floats (i.e., double)" OFF)
+if(IDX64)
+ set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=64")
+else()
+ set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=32")
+endif(IDX64)
+if(REAL64)
+ set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=64")
+else()
+ set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=32")
+endif(REAL64)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${METIS_COPTIONS}")
 
 
 # Add include directories.

--- a/libmetis/defs.h
+++ b/libmetis/defs.h
@@ -57,4 +57,7 @@
 #define KMETIS_DEFAULT_UFACTOR          30
 #define OMETIS_DEFAULT_UFACTOR          200
 
+/* Metis error during recursive bisection */
+#define METIS_ERR_INVALID_BISECTION -999999
+
 #endif


### PR DESCRIPTION
So following [issue 91](https://github.com/KarypisLab/METIS/issues/91), I suggest those modifications.

Rather simple, I added a new variable define at compile time called METIS_ERROR_INVALID_BISECTION (set to -999999) that will be returned by function MlevelRecursiveBisection that will raise an error via the metis_rcode function.

So, from my side, the only problem might be this one :
- if ever MlevelrecursiveBisection can, in normal functioning conditions, return the value -999999, then an error will be raised while it should not.

I tried to follow how things are done in Metis' code and hope Pr. Karypis will accept those changes, eventually after corrections.