### PR TITLE
Link metis and GKlib by default to fix compilation

### DIFF
--- a/libmetis/CMakeLists.txt
+++ b/libmetis/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB metis_sources *.c)
 
 # Build libmetis.
 add_library(metis ${METIS_LIBRARY_TYPE} ${metis_sources})
+target_link_libraries(metis GKlib)
 
 if(METIS_INSTALL)
   install(TARGETS metis


### PR DESCRIPTION
Thanks for making such a brilliant library! This one issue currently breaks the make process. Adding this line fixes out-of-the-box compilation. Would really appreciate if this could be merged!