### PR TITLE
Make sure to link GKlib

### DIFF
--- a/libmetis/CMakeLists.txt
+++ b/libmetis/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB metis_sources *.c)
 
 # Build libmetis.
 add_library(metis ${METIS_LIBRARY_TYPE} ${metis_sources})
+target_link_libraries(metis PRIVATE GKlib)
 
 if(METIS_INSTALL)
   install(TARGETS metis


### PR DESCRIPTION
The `-L` flags are added from the root CMakeLists.txt but the `-l` flag was not added until this. This led to lots of undefined symbols for me when linking libmetis