### PR TITLE
Fix various typos

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -117,7 +117,7 @@ r1437 | karypis | 2007-04-07 23:16:16 -0500 (Sat, 07 Apr 2007)
 - Fixed some bad memory allocation calls (i.e., sizeof(x)/sizeof(idxtype). 
   However, there are tons of those and need to be corrected once and for
   all by eliminating workspace and the associated mallocs.
-- Added mprint/mscanf family of functions for portable formated I/O
+- Added mprint/mscanf family of functions for portable formatted I/O
   of the idxtype datatype. The specifier for this datatype is %D.
   All library routines use this function for printing. 
   The implementation of these routines is not very efficient, but

--- a/include/metis.h
+++ b/include/metis.h
@@ -112,7 +112,7 @@ typedef __int64 int64_t;
 #endif
   #define iabs          labs
 #else
-  #error "Incorrect user-supplied value fo IDXTYPEWIDTH"
+  #error "Incorrect user-supplied value of IDXTYPEWIDTH"
 #endif
 
 

--- a/libmetis/coarsen.c
+++ b/libmetis/coarsen.c
@@ -455,7 +455,7 @@ idx_t Match_2Hop(ctrl_t *ctrl, graph_t *graph, idx_t *perm, idx_t *match,
     maxdegree using a 2-hop matching that involves vertices that are two 
     hops away from each other. 
     The requirement of the 2-hop matching is a simple non-empty overlap
-    between the adjancency lists of the vertices. */
+    between the adjacency lists of the vertices. */
 /**************************************************************************/
 idx_t Match_2HopAny(ctrl_t *ctrl, graph_t *graph, idx_t *perm, idx_t *match, 
           idx_t cnvtxs, size_t *r_nunmatched, size_t maxdegree)
@@ -559,7 +559,7 @@ idx_t Match_2HopAll(ctrl_t *ctrl, graph_t *graph, idx_t *perm, idx_t *match,
 
   WCOREPUSH;
 
-  /* collapse vertices with identical adjancency lists */
+  /* collapse vertices with identical adjacency lists */
   keys = ikvwspacemalloc(ctrl, nunmatched);
   for (ncand=0, pi=0; pi<nvtxs; pi++) {
     i = perm[pi];
@@ -820,7 +820,7 @@ void PrintCGraphStats(ctrl_t *ctrl, graph_t *graph)
 
 /*************************************************************************/
 /*! This function creates the coarser graph. Depending on the size of the
-    candidate adjancency lists it either uses a hash table or an array
+    candidate adjacency lists it either uses a hash table or an array
     to do duplicate detection.
  */
 /*************************************************************************/

--- a/libmetis/compress.c
+++ b/libmetis/compress.c
@@ -109,10 +109,10 @@ graph_t *CompressGraph(ctrl_t *ctrl, idx_t nvtxs, idx_t *xadj, idx_t *adjncy,
       for (j=cptr[i]; j<cptr[i+1]; j++) {
         ii = cind[j];
 
-        /* accumulate the vertex weights of the consistuent vertices */
+        /* accumulate the vertex weights of the constituent vertices */
         cvwgt[i] += (vwgt == NULL ? 1 : vwgt[ii]);
 
-        /* generate the combined adjancency list */
+        /* generate the combined adjacency list */
         for (jj=xadj[ii]; jj<xadj[ii+1]; jj++) {
           k = map[adjncy[jj]];
           if (mark[k] != i) {

--- a/libmetis/minconn.c
+++ b/libmetis/minconn.c
@@ -13,7 +13,7 @@
 
 /*************************************************************************/
 /*! This function computes the subdomain graph storing the result in the
-    pre-allocated worspace arrays */
+    pre-allocated workspace arrays */
 /*************************************************************************/
 void ComputeSubDomainGraph(ctrl_t *ctrl, graph_t *graph)
 {

--- a/libmetis/parmetis.c
+++ b/libmetis/parmetis.c
@@ -725,7 +725,7 @@ void FM_2WayNodeRefine2SidedP(ctrl_t *ctrl, graph_t *graph,
 
 /*************************************************************************/
 /*! This function computes a cache-friendly permutation of each partition.
-    The resulting permutation is retuned in old2new, which is a vector of 
+    The resulting permutation is returned in old2new, which is a vector of 
     size nvtxs such for vertex i, old2new[i] is its new vertex number. 
 */
 /**************************************************************************/


### PR DESCRIPTION
Found via `codespell -q 3 -L coo,ifset,ned,nd`