### PR TITLE
add fix thread-local storage detection for msvc

### DIFF
--- a/conf/gkbuild.cmake
+++ b/conf/gkbuild.cmake
@@ -131,7 +131,8 @@ if(MSVC)
   if("${HAVE_THREADLOCALSTORAGE}" MATCHES "^${HAVE_THREADLOCALSTORAGE}$")
     try_compile(HAVE_THREADLOCALSTORAGE
       ${CMAKE_BINARY_DIR}
-      ${CMAKE_SOURCE_DIR}/conf/check_thread_storage.c)
+      ${CMAKE_SOURCE_DIR}/conf/check_thread_storage.c
+      COMPILE_DEFINITIONS "${GK_COPTIONS}")
     if(HAVE_THREADLOCALSTORAGE)
       message(STATUS "checking for thread-local storage - found")
     else()


### PR DESCRIPTION
During the thread local storage verification process, the Microsoft Visual C++ compiler produces an incorrect result due to the undefined behavior of the __thread keyword. This leads to an Application Binary Interface (ABI) violation when linking with the GKLib library. This patch will fix it.