### PR TITLE
Fix divide-by-zero in METIS_PartGraphKway when nparts==1 (#67, #86)

### DIFF
--- a/libmetis/kmetis.c
+++ b/libmetis/kmetis.c
@@ -53,7 +53,7 @@ int METIS_PartGraphKway(idx_t *nvtxs, idx_t *ncon, idx_t *xadj, idx_t *adjncy,
   SetupKWayBalMultipliers(ctrl, graph);
 
   /* set various run parameters that depend on the graph */
-  ctrl->CoarsenTo = gk_max((*nvtxs)/(40*gk_log2(*nparts)), 30*(*nparts));
+  ctrl->CoarsenTo = gk_max((*nvtxs)/(40*gk_max(gk_log2(*nparts), 1)), 30*(*nparts));
   ctrl->nIparts   = (ctrl->nIparts != -1 ? ctrl->nIparts : (ctrl->CoarsenTo == 30*(*nparts) ? 4 : 5));
 
   /* take care contiguity requests for disconnected graphs */


### PR DESCRIPTION
## Problem
`gk_log2(1)` returns `0`, so the `CoarsenTo` computation in `libmetis/kmetis.c` divided by `40*0 == 0`. This line runs *before* the existing `nparts==1` short-circuit, so it crashed with `SIGFPE` on platforms that trap integer division by zero (e.g. x86 — see the AddressSanitizer trace in #67). On arm64 the division silently returns 0, which is why it was masked on Apple Silicon.

## Fix
Clamp the divisor with `gk_max(gk_log2(*nparts), 1)` so the 1-way case falls through to the guard that returns the trivial all-zero partition.

```diff
-  ctrl->CoarsenTo = gk_max((*nvtxs)/(40*gk_log2(*nparts)), 30*(*nparts));
+  ctrl->CoarsenTo = gk_max((*nvtxs)/(40*gk_max(gk_log2(*nparts), 1)), 30*(*nparts));
```

## Verification
- `nparts==1`: both `METIS_PartGraphKway` and `METIS_PartGraphRecursive` return `METIS_OK`, `objval=0`, all-zero partition — no crash, no hang.
- `mdual.graph` at 10/50/100 parts: edgecuts 10989 / 24086 / 32242 (monotonic), no regression.

Note: the `METIS_PartGraphRecursive` *hang* reported in #86 was already fixed in 62924b0; this PR covers the remaining `PartGraphKway` crash.

Fixes #67
Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)